### PR TITLE
Strategy selection handling

### DIFF
--- a/force-app/main/default/aura/BasePropertyPage/BasePropertyPage.cmp
+++ b/force-app/main/default/aura/BasePropertyPage/BasePropertyPage.cmp
@@ -10,6 +10,7 @@
 
     <aura:registerEvent name="propertyPageSaveRequest" type="c:propertyPageSaveRequestEvent" />
     <aura:method name="reset" action="{!c.resetPage}"> </aura:method>
+    <aura:method name="clear" action='{!c.clear}' />
 
     <ui:inputText aura:id="name" label="name" class="field" value="{!v.curNode.name}" />
     <ui:inputText aura:id="description" label="description" class="field" value="{!v.curNode.description }" />

--- a/force-app/main/default/aura/BasePropertyPage/BasePropertyPageController.js
+++ b/force-app/main/default/aura/BasePropertyPage/BasePropertyPageController.js
@@ -18,5 +18,13 @@
     //reset the page
     resetPage: function (cmp, event, helper) {
         cmp.set("v.originalName", cmp.get("v.curNode.name"));
+    },
+
+    //Clears everything related to current node and strategy
+    clear: function (cmp, event, helper) {
+        cmp.set('v.curNode', null);
+        cmp.set('v.originalName', null);
+        cmp.set('v.curStrat', null);
+        cmp.set('v.isIfNode', false);
     }
 })

--- a/force-app/main/default/aura/stratcraft/stratcraft.cmp
+++ b/force-app/main/default/aura/stratcraft/stratcraft.cmp
@@ -13,6 +13,8 @@
     <aura:attribute name="strategyNames" type="List" />
     <aura:attribute name="selectedStrategyName" type="String" default="" />
 
+    <aura:handler name="change" value="{!v.selectedStrategyName}" action="{!c.handleStrategySelection}" />
+
     <aura:handler name="init" value="{!this}" action="{!c.init}" />
 
     <aura:handler name="xmlFileUploaded" event="c:XMLFileUploaded" action="{!c.processLoadedXMLString}" />
@@ -46,18 +48,11 @@
         </div>
         <div class="slds-float_left slds-m-top_xxx-small slds-m-left_small">
 
-            <lightning:select name="strategySelect" label="Select a strategy:" aura:id="mySelect" value="{!v.selectedStrategyName}" class="select_box"
-                onchange="{!c.handleStrategySelection}">
-
+            <lightning:select name="strategySelect" label="Select a strategy:" aura:id="mySelect" value="{!v.selectedStrategyName}" class="select_box">
                 <aura:iteration items="{!v.strategyNames}" var="item">
                     <option text="{!item}" value="{!item}" />
                 </aura:iteration>
             </lightning:select>
-
-
-
-
-
 
         </div>
         <p></p>

--- a/force-app/main/default/aura/stratcraft/stratcraftController.js
+++ b/force-app/main/default/aura/stratcraft/stratcraftController.js
@@ -6,31 +6,40 @@
 
     handleUploadFinished: function (cmp, event) {
         // Get the list of uploaded files
-        var uploadedFiles = event.getParam("files");
-        alert("Files uploaded : " + uploadedFiles.length);
+        var uploadedFiles = event.getParam('files');
+        alert('Files uploaded : ' + uploadedFiles.length);
     },
 
     handleStrategySelection: function (cmp, event, helper) {
-        var strategyName = cmp.find('mySelect').get('v.value');
-        console.log('value is: ' + strategyName);
-
-        var curStratXML = helper.loadStrategyXML(cmp, strategyName);
-        console.log("exiting controller handle Strategy Selection");
-
-
+        var strategyName = cmp.get('v.selectedStrategyName');
+        var strategyNames = cmp.get('v.strategyNames');
+        //If we had at least one existing strategy at an empty option is still in the beginning of the list, we remove it
+        //so it can no longer be selected
+        if (strategyNames && strategyNames.length > 0 && strategyNames[0] === '') {
+            strategyNames = strategyNames.slice(1);
+            cmp.set('v.strategyNames', strategyNames);
+        }
+        //TODO: handle unsaved changes
+        //Since we are selecting a different strategy, we need to clear the property page
+        var propertyPageCmp = cmp.find('propertyPage');
+        if (!propertyPageCmp) {
+            throw new Error('Property page component was not found');
+        }
+        propertyPageCmp.set('v.curNode', null);
+        propertyPageCmp.clear();
+        helper.loadStrategyXML(cmp, strategyName);
     },
 
     handleMenuSelect: function (cmp, event, helper) {
-        var selectedMenuItemValue = event.getParam("value");
+        var selectedMenuItemValue = event.getParam('value');
         switch (selectedMenuItemValue) {
-            case "load":
+            case 'load':
                 //may be obsolete
                 helper.loadStrategy(cmp);
                 break;
-            case "save":
+            case 'save':
                 helper.saveStrategy(cmp);
                 break;
-
         }
     },
 
@@ -39,16 +48,16 @@
         event.preventDefault();
         var reader = new FileReader();
         var files = event.dataTransfer.files;
-        var spinner = cmp.find("mySpinner");
-        $A.util.toggleClass(spinner, "slds-hide");
+        var spinner = cmp.find('mySpinner');
+        $A.util.toggleClass(spinner, 'slds-hide');
         for (var i = 0; i < files.length; i++) {
             var file = files[i];
             reader = new FileReader();
             reader.onloadend = function () {
-                console.log("uploaded file data is: " + reader.result);
-                cmp.set("v.strategyXML", reader.result);
+                console.log('uploaded file data is: ' + reader.result);
+                cmp.set('v.strategyXML', reader.result);
 
-                var cmpEvent = cmp.getEvent("xmlFileUploaded");
+                var cmpEvent = cmp.getEvent('xmlFileUploaded');
                 cmpEvent.fire();
             };
             reader.readAsText(file);
@@ -59,7 +68,7 @@
     processLoadedXMLString: function (cmp, event, helper) {
         console.log('starting processing loaded xml string');
         //initialize the tree component
-        var strategyXMLString = cmp.get("v.strategyXML");
+        var strategyXMLString = cmp.get('v.strategyXML');
         var tree = cmp.find('tree');
         tree.initialize(strategyXMLString);
 
@@ -68,16 +77,14 @@
         console.log('completed processing of loaded xml string');
     },
 
-
-
     onDragOver: function (component, event) {
         event.preventDefault();
     },
 
     handleTreeNodeSelect: function (component, event, helper) {
         //return name of selected tree item
-        var newSelectedNodeName = event.getParam("name");
-        var curStrat = component.get("v.curStrat");
+        var newSelectedNodeName = event.getParam('name');
+        var curStrat = component.get('v.curStrat');
 
         var curNode = helper.findStrategyNodeByName(curStrat, newSelectedNodeName);
 
@@ -86,17 +93,17 @@
             if (curNode.name === newSelectedNodeName) {
 
                 //continue navigation callback
-                component.find("propertyPage").set("v.curNode", _utils.clone(curNode, true));
-                component.find("propertyPage").set("v.originalName", newSelectedNodeName);
+                component.find('propertyPage').set('v.curNode', _utils.clone(curNode, true));
+                component.find('propertyPage').set('v.originalName', newSelectedNodeName);
             }
 
         });
     },
 
     saveStrategy: function (component, event, helper) {
-        console.log("in save strategy in parent controller");
-        var originalNodeName = event.getParam("originalNodeName");
-        var changedNode = event.getParam("changedStrategyNode");
+        console.log('in save strategy in parent controller');
+        var originalNodeName = event.getParam('originalNodeName');
+        var changedNode = event.getParam('changedStrategyNode');
 
 
         helper.saveStrategyChanges(component, changedNode, originalNodeName, helper);

--- a/force-app/main/default/aura/stratcraft/stratcraftHelper.js
+++ b/force-app/main/default/aura/stratcraft/stratcraftHelper.js
@@ -1,21 +1,24 @@
 ({
 
-  //populates the select strategy drop down
+  //Populates the select strategy drop down
   loadStrategyNames: function (cmp) {
-    // Create the action
-    var action = cmp.get("c.getStrategyNames");
-
-    // Add callback behavior for when response is received
+    var action = cmp.get('c.getStrategyNames');
     action.setCallback(this, function (response) {
       var state = response.getState();
       if (state === "SUCCESS") {
-        cmp.set("v.strategyNames", response.getReturnValue());
+        //If we got at least one strategy, we add an empty name in the beginning of the list, so no strategy is selected by default
+        var strategies = response.getReturnValue();
+        if (!strategies || strategies.length === 0) {
+          cmp.set('v.strategyNames', []);
+        }
+        else {
+          cmp.set('v.strategyNames', [''].concat(strategies));
+        }
       }
       else {
-        console.log("Failed with state: " + state);
+        console.log('Failed with state: ' + state);
       }
     });
-    // Send action off to be executed
     $A.enqueueAction(action);
   },
 

--- a/force-app/main/default/classes/BuildTree.cls
+++ b/force-app/main/default/classes/BuildTree.cls
@@ -12,7 +12,7 @@ public with sharing class BuildTree {
 
 		public TreeNode() {
 			items = new List<TreeNode>();
-			expanded = false;
+			expanded = true;
 		}
     }
 


### PR DESCRIPTION
- Created a single point for strategy selection change handling
- No strategy is displayed as selected by default
- When existing strategy is selected, an empty option can no longer be selected
- When strategy is selected, its tree appears fully expanded
- When another strategy is selected, property pane is cleared

![st-24 demo](https://user-images.githubusercontent.com/4508264/36060873-cbd8a184-0e06-11e8-9a46-097b249ec897.gif)
